### PR TITLE
Update process_timesheet.py

### DIFF
--- a/process_timesheet.py
+++ b/process_timesheet.py
@@ -83,9 +83,9 @@ class TimesheetProcessor:
     ]
 
     regex_wfo = [
-        r'(?P<dayOfMonth>\d{2}) (?P<dayOfWeek>\w{2}).*(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5}).*(?P<overTime>[\d.,]{4,5})', # work from office
+        r'(?P<dayOfMonth>\d{2}) (?P<dayOfWeek>\w{2})((?!Dienstr/).)*(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5}).*(?P<overTime>[\d.,]{4,5})', # work from office
         r'Weiterbildung\s+(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5})', # training
-        r'\s+anger. Arbeitszeit\s+(?P<actualWorkTime>[\d.,]{4,5})',
+        r'\s+anger. Arbeitszeit\s+(?P<actualWorkTime>[\d.,]{4,5})', # business trip
     ]
 
     def __init__(self, input_source, quota, date_format):

--- a/process_timesheet.py
+++ b/process_timesheet.py
@@ -85,7 +85,7 @@ class TimesheetProcessor:
     regex_wfo = [
         r'(?P<dayOfMonth>\d{2}) (?P<dayOfWeek>\w{2})((?!Dienstr/).)*(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5}).*(?P<overTime>[\d.,]{4,5})', # work from office
         r'Weiterbildung\s+(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5})', # training
-        r'\s+anger. Arbeitszeit\s+(?P<actualWorkTime>[\d.,]{4,5})', # business trip
+        r'\s+anger. Arbeitszeit\s+(?P<actualWorkTime>[\d.,]{4,5})',
     ]
 
     def __init__(self, input_source, quota, date_format):


### PR DESCRIPTION
Updated general office hours regexp to ignore partial business trip hours.

Example:
An entry like:
`04 MI      Dienstr/Reisez Arb      07:00       07:30            1,00      0,50     8,00                    M`
will lead to 0,5h to be counted as office hours, but that's not true, since only `anger. Arbeitszeit` entry should be used in case of business travel.

However, since `report.work_from_office` value is not really used in final calculations — it makes zero effect on resulting numbers :)
But I thought it would be good to have some "hidden" issues.