### PR TITLE
Updated regex_office_day

### DIFF
--- a/process_timesheet.py
+++ b/process_timesheet.py
@@ -30,7 +30,7 @@ regex_wfh = [
 compiled_regex_full_work_from_home = re.compile(regex_full_work_from_home)
 compiled_regex_partial_work_from_home = re.compile(regex_partial_work_from_home)
 
-regex_office_day = r'(?P<dayOfMonth>\d{2}) (?P<dayOfWeek>\w{2})((?!Dienstr/).)*(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5}).*(?P<overTime>[\d.,]{4,5})' # work from office
+regex_office_day = r'(?P<dayOfMonth>\d{2}) (?P<dayOfWeek>\w{2})((?!Dienstr/).)*(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5})?.*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5}).*(?P<overTime>[\d.,]{4,5})?' # work from office
 regex_wfo = [
     regex_office_day,
     r'Weiterbildung\s+(?P<startTime>\d{2}:\d{2}).*(?P<endTime>\d{2}:\d{2}).*(?P<break>[\d.,]{4,5}).*(?P<actualWorkTime>[\d.,]{4,5}).*(?P<expectedWorkTime>[\d.,]{4,5})', # training


### PR DESCRIPTION
it seems, that `<break>` value is optional, and `<overTime>` might be missing as well:

```
03 DI      ganztäg.Mobilarbeit                                        8,00     8,00
04 MI                                  09:06     14:28       0,25     5,12     8,00                                              2,88-
05 DO                                  08:59   P 17:11   P   1,00     7,20     8,00                                              0,80-
06 FR                                  09:34     12:34                3,00     8,00
07 SA
08 SO      Pfingstsonntag
```
or another example:
```
26 DO                                  08:42     14:49       1,00     5,12     8,00                                              2,88-
27 FR                                  08:40     12:17                3,62     8,00                                              4,38-
```